### PR TITLE
Remove 'Core' from .Net 6 references

### DIFF
--- a/docs/new-extensibility-model/getting-started/oop-extensibility-model-overview.md
+++ b/docs/new-extensibility-model/getting-started/oop-extensibility-model-overview.md
@@ -26,9 +26,9 @@ Writing extensions using the new model provides the following benefits:
 
 * **Increased reliability** – Extensions written with the new model are out-of-proc and will not block the Visual Studio UI.  This means that if the extension crashes, VS will not crash as a result. 
 * **Reduced API complexity** – The new model’s wrapper API has been built from the ground-up to be more cohesive and simpler to implement while retaining the old model’s advanced functionality.
-* **.NET Core Only** – In order to benefit from latest enhancements on .NET and C#, the new extensibility model will only support .NET Core 6 and forward. All APIs will also be built on .NET Core, will be .NET 6 compatible, and extensions will be loaded in a .NET Core host.
+* **.NET 6 Only** – In order to benefit from latest enhancements on .NET and C#, the new extensibility model will only support .NET 6 moving forward. All APIs will also be built on .NET 6, will be .NET 6 compatible, and extensions will be loaded in a .NET 6 host.
 * **Hot-loading functionality** – Excluding ones requiring VS component prerequisites that haven’t been installed yet, extensions written using the new model can be installed and loaded without needing to restart Visual Studio.
-* **Cross-CPU Platform** – Since underlying implementation is based on RPC compatible brokered services and is .NET Core based, all extensions will run on all CPU platforms supported by .NET Core runtime.
+* **Cross-CPU Platform** – Since underlying implementation is based on RPC compatible brokered services and is .NET based, all extensions will run on all CPU platforms supported by .NET 6 runtime.
 * **Low-trust extensions (Coming Soon)** – Since extensions in the new model run in a separate process, they can be isolated from devenv and ran in a low-trust sandbox. This environment will provide the extensions with read-only access to the file system and controlled writing access via the model’s APIs. 
 
 ## Technology


### PR DESCRIPTION
The 'Core' concept was removed starting with .Net 5.