### PR TITLE
Update getting started doc to reflect VS version requirement change

### DIFF
--- a/docs/new-extensibility-model/getting-started/create-your-first-extension.md
+++ b/docs/new-extensibility-model/getting-started/create-your-first-extension.md
@@ -1,7 +1,7 @@
 ---
 title: Creating your first extension reference
 description: A reference for creating your first OOP extension
-date: 2022-07-28
+date: 2022-11-22
 ---
 
 # Creating your first out-of-process Visual Studio extension
@@ -11,11 +11,11 @@ This document is a quick walkthrough on how to create your first extension using
 
 ## Prerequisites
 
-* Visual Studio 2022.4 Preview 3 or higher with `.Net desktop development` workload.
+* Visual Studio 2022.5 Preview 1 or higher with `.Net desktop development` workload. The latest minimum requirement will always be listed at [Announcements](../..announcements.md) page.
 
 * Install latest version of [VisualStudio.Extensibility Project System](https://marketplace.visualstudio.com/items?itemName=vsext.gladstone): This extension will allow you to debug extension projects using F5. There is currently no other deployment mechanism supported.
 
-* If you are updating from Visual Studio 2022.4 Preview 1, please make sure to update VisualStudio.Extensibility Project System to latest version as there are breaking changes in VisualStudio.Extensibility packages.
+* If you are updating from earlier builds, please make sure to update VisualStudio.Extensibility Project System to latest version as there are breaking changes in VisualStudio.Extensibility packages.
 
 ## Create the extension project
 

--- a/docs/new-extensibility-model/getting-started/create-your-first-extension.md
+++ b/docs/new-extensibility-model/getting-started/create-your-first-extension.md
@@ -11,7 +11,7 @@ This document is a quick walkthrough on how to create your first extension using
 
 ## Prerequisites
 
-* Visual Studio 2022.5 Preview 1 or higher with `.Net desktop development` workload. The latest minimum requirement will always be listed at [Announcements](../..announcements.md) page.
+* Visual Studio 2022.5 Preview 1 or higher with `.Net desktop development` workload. The latest minimum requirement will always be listed at [Announcements](../../announcements.md) page.
 
 * Install latest version of [VisualStudio.Extensibility Project System](https://marketplace.visualstudio.com/items?itemName=vsext.gladstone): This extension will allow you to debug extension projects using F5. There is currently no other deployment mechanism supported.
 


### PR DESCRIPTION
We now require Visual Studio 2022.5 Preview 1 but this was not reflected in getting started documentation.