### PR TITLE
Fix type names for object sources in visualizer sample

### DIFF
--- a/New_Extensibility_Model/Samples/RegexMatchDebugVisualizer/RegexMatchDebugVisualizer/RegexMatch/RegexMatchDebuggerVisualizerProvider.cs
+++ b/New_Extensibility_Model/Samples/RegexMatchDebugVisualizer/RegexMatchDebugVisualizer/RegexMatch/RegexMatchDebuggerVisualizerProvider.cs
@@ -30,7 +30,7 @@ internal class RegexMatchDebuggerVisualizerProvider : DebuggerVisualizerProvider
 	/// <inheritdoc/>
 	public override DebuggerVisualizerProviderConfiguration DebuggerVisualizerProviderConfiguration => new("Regex Match visualizer", typeof(Match))
 	{
-		VisualizerObjectSourceType = new("Microsoft.VisualStudio.Gladstone.RegexMatchVisualizer.ObjectSource.RegexMatchObjectSource, RegexMatchObjectSource"),
+		VisualizerObjectSourceType = new("RegexMatchVisualizer.ObjectSource.RegexMatchObjectSource, RegexMatchObjectSource"),
 	};
 
 	/// <inheritdoc/>

--- a/New_Extensibility_Model/Samples/RegexMatchDebugVisualizer/RegexMatchDebugVisualizer/RegexMatchCollection/RegexMatchCollectionDebuggerVisualizerProvider.cs
+++ b/New_Extensibility_Model/Samples/RegexMatchDebugVisualizer/RegexMatchDebugVisualizer/RegexMatchCollection/RegexMatchCollectionDebuggerVisualizerProvider.cs
@@ -29,7 +29,7 @@ internal class RegexMatchCollectionDebuggerVisualizerProvider : DebuggerVisualiz
 	/// <inheritdoc/>
 	public override DebuggerVisualizerProviderConfiguration DebuggerVisualizerProviderConfiguration => new("Regex Match visualizer", typeof(MatchCollection))
 	{
-		VisualizerObjectSourceType = new("Microsoft.VisualStudio.Gladstone.RegexMatchVisualizer.ObjectSource.RegexMatchCollectionObjectSource, RegexMatchObjectSource"),
+		VisualizerObjectSourceType = new("RegexMatchVisualizer.ObjectSource.RegexMatchCollectionObjectSource, RegexMatchObjectSource"),
 	};
 
 	/// <inheritdoc/>


### PR DESCRIPTION
Visualizer sample was broken because object source type names were incorrect.