### PR TITLE
Update experimental_apis.md to show properties and build properties.

### DIFF
--- a/docs/experimental_apis.md
+++ b/docs/experimental_apis.md
@@ -53,3 +53,4 @@ As of our 17.9 release, there are three experimental features:
 | LSP | VSEXTPREVIEW_LSP | LSP support was added with our 17.9 release and we want user feedback to make sure we've got the features needed by extension authors.|
 | Output Window | VSEXTPREVIEW_OUTPUTWINDOW | We're updating our output window APIs based on user feedback to provide a simplified way to write to the output window. |
 | Project Query Tracking | VSEXTPREVIEW_PROJECTQUERY_TRACKING | We're continuing to update our project query API to add new features|
+| Project Query Properties and Build Properties | VSEXTPREVIEW_PROJECTQUERY_PROPERTIES_BUILDPROPERTIES | We're continuing to update our project query API to use updated and accurate terminology. |

--- a/docs/experimental_apis.md
+++ b/docs/experimental_apis.md
@@ -53,4 +53,4 @@ As of our 17.9 release, there are three experimental features:
 | LSP | VSEXTPREVIEW_LSP | LSP support was added with our 17.9 release and we want user feedback to make sure we've got the features needed by extension authors.|
 | Output Window | VSEXTPREVIEW_OUTPUTWINDOW | We're updating our output window APIs based on user feedback to provide a simplified way to write to the output window. |
 | Project Query Tracking | VSEXTPREVIEW_PROJECTQUERY_TRACKING | We're continuing to update our project query API to add new features|
-| Project Query Properties and Build Properties | VSEXTPREVIEW_PROJECTQUERY_PROPERTIES_BUILDPROPERTIES | We're continuing to update our project query API to use updated and accurate terminology. |
+| Project Query Properties and Build Properties | VSEXTPREVIEW_PROJECTQUERY_PROPERTIES_BUILDPROPERTIES | We're continuing to update our project query API to address user feedback and add new features |


### PR DESCRIPTION
We added VSEXTPREVIEW_PROJECTQUERY_PROPERTIES_BUILDPROPERTIES to some apis in project query in 17.9 this pr changes the public documentation so that it is known that these are experimental.